### PR TITLE
Fix backend-build missing on .awsmobile folder

### DIFF
--- a/lib/aws-operations/mobile-api-content-generator.js
+++ b/lib/aws-operations/mobile-api-content-generator.js
@@ -24,6 +24,7 @@ function generateContents(projectInfo, backendProjectSpec, callback) {
     let contentZipFilePath = pathManager.getBackendContentZipFilePath(projectInfo.ProjectPath)
     let zipInternalFilePath = 'awsmobile-cli-project/' + awsmobileJSConstant.BackendProjectYamlFileName
 
+    fs.ensureDirSync(pathManager.getBackendBuildDirPath(projectInfo.ProjectPath));
     awsMobileYamlOps.dumpYaml(backendProjectSpec, tempContentYmlFilePath)
 
     let output = fs.createWriteStream(contentZipFilePath)


### PR DESCRIPTION
This fix the problem on existing projects that doesn't have .awsmobile/backend-build folder