### PR TITLE
Fix typo in local backend specs log

### DIFF
--- a/bin/awsmobile-features
+++ b/bin/awsmobile-features
@@ -58,6 +58,6 @@ function selectFeatures(){
         })
     }else{
         console.log(chalk.red('local backend specs appear to be corrupted'))
-        console.log('please restored the local backend specs to valid state before continuing')
+        console.log('please restore the local backend specs to a valid state before continuing')
     }
 }

--- a/lib/backend-operations/backend-spec-manager.js
+++ b/lib/backend-operations/backend-spec-manager.js
@@ -42,7 +42,7 @@ function listEnabledFeatures(projectInfo){
         }
     }else{
         console.log(chalk.red('local backend specs appear to be corrupted'))
-        console.log('please restored the local backend specs to valid state before continuing')
+        console.log('please restore the local backend specs to a valid state before continuing')
     }
 }
 
@@ -163,7 +163,7 @@ function disableFeature(projectInfo, featureName){
         }
     }else{
         console.log(chalk.red('local backend specs appear to be corrupted'))
-        console.log('please restored the local backend specs to valid state before continuing')
+        console.log('please restore the local backend specs to a valid state before continuing')
     }
 }
 
@@ -182,7 +182,7 @@ function configureFeature(projectInfo, featureName){
         }
     }else{
         console.log(chalk.red('local backend specs appear to be corrupted'))
-        console.log('please restored the local backend specs to valid state before continuing')
+        console.log('please restore the local backend specs to a valid state before continuing')
     }
 }
 
@@ -235,7 +235,7 @@ function onBackendFormatChange(projectInfo)
             fs.removeSync(backendProjectYamlFilePath)
         }else{
             console.log(chalk.red('local backend specs appear to be corrupted'))
-            console.log('please restored the local backend specs to valid state before continuing')
+            console.log('please restore the local backend specs to a valid state before continuing')
         }
     }else if(fs.existsSync(backendProjectJsonFilePath) && projectInfo.BackendFormat == backendFormats.Yaml){
         backendProject = awsMobileYamlOps.loadJson(backendProjectJsonFilePath)
@@ -244,7 +244,7 @@ function onBackendFormatChange(projectInfo)
             fs.removeSync(backendProjectJsonFilePath)
         }else{
             console.log(chalk.red('local backend specs appear to be corrupted'))
-            console.log('please restored the local backend specs to valid state before continuing')
+            console.log('please restore the local backend specs to a valid state before continuing')
         }
     }
 }

--- a/lib/project-backend-builder.js
+++ b/lib/project-backend-builder.js
@@ -50,7 +50,7 @@ function build(callback) {
             }
         }else{
             console.log(chalk.red('local backend specs appear to be corrupted'))
-            console.log('please restored the local backend specs to valid state before continuing')
+            console.log('please restore the local backend specs to a valid state before continuing')
         }
     }
 }


### PR DESCRIPTION
Small grammatical correction.

This can be further improved by explaining *how* users can restore their local backend specs to a valid state.