### PR TITLE
remove clone option in downloadGitRepo

### DIFF
--- a/lib/awsmobilestarter-manager.js
+++ b/lib/awsmobilestarter-manager.js
@@ -70,7 +70,7 @@ function placeStarter(projectPath, repo, callback){
   let tempClientDirPath = path.join(tempDirPath, 'client')
 
   spinner.start()
-  downloadGitRepo(repo, tempDirPath, { clone: true }, function (err) {
+  downloadGitRepo(repo, tempDirPath, function (err) {
       spinner.stop()
       if (err) {
           console.log(chalk.red('Failed to download starter ' + repo))


### PR DESCRIPTION
     - clone: true is only for private repos (see https://github.com/flipxfx/download-git-repo/issues/19#issuecomment-365971553)
     - fixes #62 