### PR TITLE
suppress errors on init, as no configuration is available

### DIFF
--- a/lib/aws-operations/mobile-yaml-ops.js
+++ b/lib/aws-operations/mobile-yaml-ops.js
@@ -19,12 +19,15 @@ const util = require('util')
 
 const ymalSchema = require('./mobile-yaml-schema.js')
 
-function readYamlFileSync(ymlFilePath){
+function readYamlFileSync(ymlFilePath, suppressErrors = false){
     let backendProject
     try{
         let yml = fs.readFileSync(ymlFilePath)
         backendProject = jsyaml.safeLoad(yml, { schema: ymalSchema.AWS_MOBILE_YAML_SCHEMA, noCompatMode: true, scalarType: 5, noRefs: true, skipInvalid: true })
     }catch(e){
+        if (suppressErrors) {
+            return undefined
+        }
         console.log(chalk.red('error occured in parsing the yaml file:'))
         console.log(ymlFilePath)
         console.log(e)

--- a/lib/command-init.js
+++ b/lib/command-init.js
@@ -24,6 +24,7 @@ function init(mobileProjectID, yesFlag){
 
     let projectPath = process.cwd()
     let initInfo = {
+        initNewProject: true,
         projectPath: projectPath,
         yesFlag: yesFlag,
         mobileProjectID: mobileProjectID

--- a/lib/init-steps/s1-analyze-project.js
+++ b/lib/init-steps/s1-analyze-project.js
@@ -42,7 +42,7 @@ function run(initInfo){
             initInfo.backupAWSMobileJSDirPath = undefined
             initInfo.projectInfo = getProjectInfo(initInfo.projectPath)
             initInfo.projectConfig = getProjectConfig(initInfo.projectPath)
-            initInfo.backendProject = getBackendProject(initInfo.projectPath)
+            initInfo.backendProject = getBackendProject(initInfo.projectPath, initInfo.initNewProject)
             initInfo.packageJson = getPackageJson(initInfo.projectPath)
             initInfo.framework = guessFramework(initInfo)
             initInfo.initialStage = guessProjectStage(initInfo)
@@ -77,9 +77,9 @@ function getProjectConfig(projectPath){
     return result
 }
 
-function getBackendProject(projectPath){
+function getBackendProject(projectPath, suppressErrors = false){
     let backendProjectYamlFilePath = pathManager.getBackendSpecProjectYmlFilePath(projectPath)
-    let backendProject = awsMobileYamlOps.readYamlFileSync(backendProjectYamlFilePath)
+    let backendProject = awsMobileYamlOps.readYamlFileSync(backendProjectYamlFilePath, suppressErrors)
     return backendProject
 }
 


### PR DESCRIPTION
The latest release broke the init command. On initialization there's unfortunately not a valid yaml file available. Pull request #76 added a re-throw of the exception, which broke the init command. I'm now simply suppressing errors on init.