### PR TITLE
Fix amplify version (package.json), dependency on invoke

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/aws/awsmobile-cli",
   "dependencies": {
     "archiver": "^2.1.0",
-    "aws-amplify": "^0.2.0",
+    "aws-amplify": "0.2.11",
     "aws-sdk": "^2.131.0",
     "chalk": "^2.0.1",
     "commander": "^2.11.0",


### PR DESCRIPTION
*Issue #, if available:*
Fix issue on invoke cmd (use aws-amplify 0.2.11)
*Description of changes:*
Updating package.json

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
