### PR TITLE
Add aws-amplify-angular depndency when inititalizing angular project …

### DIFF
--- a/__tests__/lib/utils/dependency-manager.test.js
+++ b/__tests__/lib/utils/dependency-manager.test.js
@@ -105,6 +105,17 @@ describe('project info manager functions', () => {
         })
     })
 
+    test('setupAmplifyDependency angular', () => {
+        let mock_initInfo = {
+            projectPath: projectPath,
+            packageJson: mock_packageJson,
+            framework: 'angular'
+        }
+        dependencyManager.setupAmplifyDependency(mock_initInfo).then((initInfo)=>{
+            expect(spawn).toBeCalled()
+        })
+    })
+
     test('setupAmplifyDependency default', () => {
         let mock_initInfo = {
             projectPath: projectPath,

--- a/__tests__/lib/utils/starter-config-mapping.test.js
+++ b/__tests__/lib/utils/starter-config-mapping.test.js
@@ -17,6 +17,7 @@ describe('feature-yaml-template-mapping', () => {
     test('feature-yaml-template-mapping defined', () => {
         expect(starterConfigMapping['react']).toBeDefined()
         expect(starterConfigMapping['react-native']).toBeDefined()
+        expect(starterConfigMapping['angular']).toBeDefined()
         expect(starterConfigMapping['ionic']).toBeDefined()
         expect(starterConfigMapping['vue']).toBeDefined()
     })

--- a/__tests__/lib/utils/starter-repo-mapping.test.js
+++ b/__tests__/lib/utils/starter-repo-mapping.test.js
@@ -17,5 +17,6 @@ describe('feature-yaml-template-mapping', () => {
     test('feature-yaml-template-mapping defined', () => {
         expect(starterRepoMapping['react']).toBeDefined()
         expect(starterRepoMapping['react-native']).toBeDefined()
+        expect(starterRepoMapping['angular']).toBeDefined()
     })
 })

--- a/__tests__/lib/utils/starter-repo-mapping.test.js
+++ b/__tests__/lib/utils/starter-repo-mapping.test.js
@@ -17,6 +17,5 @@ describe('feature-yaml-template-mapping', () => {
     test('feature-yaml-template-mapping defined', () => {
         expect(starterRepoMapping['react']).toBeDefined()
         expect(starterRepoMapping['react-native']).toBeDefined()
-        expect(starterRepoMapping['angular']).toBeDefined()
     })
 })

--- a/lib/utils/dependency-manager.js
+++ b/lib/utils/dependency-manager.js
@@ -72,6 +72,13 @@ function setupAmplifyDependency(initInfo){
                             return initInfo
                         })
             break
+            case 'angular': 
+                result = yarnAddAmplify(projectPath)
+                        .then(yarnAddAmplifyAngular)
+                        .then((cwd)=>{
+                            return initInfo
+                        })
+            break
             default: 
                 result = npmInstallAmplify(projectPath)
                         .then((cwd)=>{
@@ -116,6 +123,14 @@ function yarnAddAmplifyReactNative(cwd){
     }
 }
 
+function yarnAddAmplifyAngular(cwd){
+    if(isYarnInstalled()){
+        return spawnChildProcess(yarn, ['add', 'aws-amplify-angular'], cwd)
+    }else{
+        return spawnChildProcess(npm, ['install', 'aws-amplify-angular'], cwd)
+    }
+}
+
 function isYarnInstalled(){
     var isYarnInstalled
     try {
@@ -128,6 +143,7 @@ function isYarnInstalled(){
 }
 
 function spawnChildProcess(command, args, cwd){
+
     return new Promise((resolve, reject)=>{
         console.log()
         console.log('Executing ' + command + ' ' + args.join(' ') + ' ...')

--- a/lib/utils/starter-config-mapping.js
+++ b/lib/utils/starter-config-mapping.js
@@ -14,6 +14,7 @@
 const frameworkConfigMappings = require('./framework-config-mapping.js')
 
 const reactConfig = frameworkConfigMappings['react']
+const angularConfig = frameworkConfigMappings['angular']
 
 let reactNativeConfig = frameworkConfigMappings['react-native']
 reactNativeConfig.SourceDir = 'src'
@@ -25,6 +26,7 @@ const vueConfig = frameworkConfigMappings['vue']
 module.exports = {
     'react': reactConfig,
     'react-native': reactNativeConfig,
+    'angular': angularConfig,
     'ionic': ionicConfig,
     'vue': vueConfig
 }

--- a/lib/utils/starter-repo-mapping.js
+++ b/lib/utils/starter-repo-mapping.js
@@ -14,6 +14,7 @@
 module.exports = {
     'react': "aws-samples/aws-mobile-react-sample",
     'react-native': "aws-samples/aws-mobile-react-native-starter",
+    'angular': "aws-amplify-angular-sample"
     // 'ionic': "awslabs/aws-mobile-ionic-sample",
     // 'vue': "awslabs/vue-sample"
 }

--- a/lib/utils/starter-repo-mapping.js
+++ b/lib/utils/starter-repo-mapping.js
@@ -14,7 +14,7 @@
 module.exports = {
     'react': "aws-samples/aws-mobile-react-sample",
     'react-native': "aws-samples/aws-mobile-react-native-starter",
-    'angular': "aws-amplify-angular-sample"
+    // 'angular': "aws-amplify-angular-sample"
     // 'ionic': "awslabs/aws-mobile-ionic-sample",
     // 'vue': "awslabs/vue-sample"
 }


### PR DESCRIPTION
…through CLI & ability to setup angular base project through the CLI

*Issue #, if available:*

*Description of changes:*
1) Add amplify angular HOC dependency when performing an init on an angular project similar to react and react native 
===Commented this feature out since sample angular package not ready ===
2) Add angular starter package on CLI start command (needs verification from the team if the package used is correct or not) -  https://github.com/aws-samples/aws-amplify-angular-sample

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
