### PR TITLE
Add sync to dev flag as a flag to awsmobile pull

### DIFF
--- a/bin/awsmobile-pull
+++ b/bin/awsmobile-pull
@@ -19,12 +19,14 @@ const chalk = require('chalk')
 
 program
   .description('pull the latest details of the awsmobile project from the cloud')
+  .usage('[options]')
+  .option('-d, --sync-dev <value>', 'synchronize contents in #current-backend-info/ with the latest in the aws cloud', 0)
   .parse(process.argv)
 
 let projectInfo = projectInfoManager.getProjectInfo()
 if(projectInfo){
   if(projectInfo.BackendProjectID && projectInfo.BackendProjectID.length > 0){
-    backendRetrieve.pullBackend(projectInfo, projectInfo.BackendProjectID, 0, null)
+    backendRetrieve.pullBackend(projectInfo, projectInfo.BackendProjectID, program.syncDev, null)
   }else{
     console.log(chalk.red('backend awsmobile project unknown'))
   }


### PR DESCRIPTION
*Issue #, if available:*

#142

*Description of changes:*

The `$ awsmobile pull` command now accepts `-d`/`--sync-dev` set the `syncToDevFlag`, which is responsible for prompting the user on how to synchronise local files with those in AWS.

*Usage*

The default value remains 0, "prompt for confirmation"
`$ awsmobile pull`

Manually specify the `syncToDevFlag` to not sync to backend
`$ awsmobile pull --sync-dev=-1` *or* `$ awsmobile pull -d=-1`

etc

*Help*

The output from `$ awsmobile pull --help` is now:

```

  Usage: awsmobile-pull [options]

  pull the latest details of the awsmobile project from the cloud

  Options:

    -d, --sync-dev <value>  synchronize contents in #current-backend-info/ with the latest in the aws cloud (default: 0)
    -h, --help              output usage information
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
