### PR TITLE
Added a --skip-deps flag to skip installing Amplify JS dependencies

### DIFF
--- a/__tests__/lib/command-init.test.js
+++ b/__tests__/lib/command-init.test.js
@@ -86,6 +86,30 @@ describe('command init', () => {
         })
     })
 
+    test('init succeeds when passing a yes command to supress console input', () => {
+        return commandInit.init('mobileProjectID', true).then(() => {
+            expect(analyzeProject.run).toBeCalled()
+            expect(chooseStrategy.run).toBeCalled()
+            expect(initialize.run).toBeCalled()
+            expect(configure.run).toBeCalled()
+            expect(setupBackend.run).toBeCalled()
+            expect(onSuccess.run).toBeCalled()
+            expect(onFailure.run).not.toBeCalled()
+        })
+    })
+
+    test('init succeeds when passing a skipDeps command to skip installing dependencies', () => {
+        return commandInit.init('mobileProjectID', false, true).then(() => {
+            expect(analyzeProject.run).toBeCalled()
+            expect(chooseStrategy.run).toBeCalled()
+            expect(initialize.run).toBeCalled()
+            expect(configure.run).toBeCalled()
+            expect(setupBackend.run).toBeCalled()
+            expect(onSuccess.run).toBeCalled()
+            expect(onFailure.run).not.toBeCalled()
+        })
+    })
+
     test('init fails', () => {
 
         setupBackend.run = jest.fn((initInfo)=>{

--- a/__tests__/lib/init-steps/s60-on-success.test.js
+++ b/__tests__/lib/init-steps/s60-on-success.test.js
@@ -75,4 +75,14 @@ describe('s60 on success', () => {
             expect(fs.writeFileSync).toBeCalled()
         })
     })
+
+    test('run with skipInstallingDependencies set', () => {
+        dependencyManager.setupAmplifyDependency.mockReset()
+        const custom_initInfo = Object.assign({}, mock_initInfo, { skipInstallingDependencies: true })
+		return onSuccess.run(custom_initInfo).then((initInfo)=>{
+            expect(dependencyManager.setupAmplifyDependency).not.toBeCalled()
+            expect(gitManager.insertAwsmobilejs).toBeCalled()
+            expect(fs.writeFileSync).toBeCalled()
+        })
+    })
 })

--- a/bin/awsmobile-init
+++ b/bin/awsmobile-init
@@ -36,6 +36,7 @@ program
   .usage('[awsmobile-project-id] [options]')
   .option('-y, --yes', 'suppress console input and use default in the init procedure')
   .option('-r, --remove', 'remove awsmobilejs from the current project')
+  .option('-s, --skip-deps', 'skip installing Javscript dependencies')
   .parse(process.argv)
 
 if(program.remove){
@@ -45,5 +46,9 @@ if(program.remove){
   if(program.args && program.args.length > 0){
     mobileProjectID = program.args[0]
   }
-  commandInit.init(mobileProjectID, program.yes)
+  let skipInstallingDependencies = false;
+  if(program.skipDeps){
+    skipInstallingDependencies = true;
+  }
+  commandInit.init(mobileProjectID, program.yes, skipInstallingDependencies)
 }

--- a/lib/command-init.js
+++ b/lib/command-init.js
@@ -20,13 +20,14 @@ const setupBackend = require('./init-steps/s5-setup-backend.js')
 const onSuccess = require('./init-steps/s60-on-success.js')
 const onFailure = require('./init-steps/s61-on-failure.js')
 
-function init(mobileProjectID, yesFlag){
+function init(mobileProjectID, yesFlag, skipInstallingDependencies){
 
     let projectPath = process.cwd()
     let initInfo = {
         projectPath: projectPath,
         yesFlag: yesFlag,
-        mobileProjectID: mobileProjectID
+        mobileProjectID: mobileProjectID,
+        skipInstallingDependencies: skipInstallingDependencies,
     }
 
     return analyzeProject.run(initInfo)

--- a/lib/init-steps/s60-on-success.js
+++ b/lib/init-steps/s60-on-success.js
@@ -23,8 +23,14 @@ const gitManager = require('../utils/git-manager.js')
 function run(initInfo){
     let result = initInfo
     if(initInfo.strategy){
-        result = dependencyManager.setupAmplifyDependency(initInfo)
-        .then((initInfo)=>{
+        if(initInfo.skipInstallingDependencies){
+            console.log('Skipping Amplify dependency installation')
+            result = Promise.resolve(initInfo);
+        } else {
+            result = dependencyManager.setupAmplifyDependency(initInfo);
+        }
+
+        result = result.then((initInfo)=>{
             gitManager.insertAwsmobilejs(initInfo.projectPath)
             
             delete initInfo.projectInfo.SourceDir


### PR DESCRIPTION
*Issue #, if available:*
#146

*Description of changes:*
In this PR I've added a `--skip-deps` or `-s` flag to the `awsmobile init` command. When this flag is set, Amplify JS dependencies will not be installed. A message "Skipping Amplify Dependency installation" will be shown.

See issue #146 for more details about why this is needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
