### PR TITLE
BROWSER=none don't open browser after publish

### DIFF
--- a/lib/command-publish.js
+++ b/lib/command-publish.js
@@ -169,7 +169,9 @@ function onPublishComplete(err)
             console.log("Successful!")
             console.log("your application is published and hosted at:")
             console.log(chalk.green(_hostingInfo.hostingSiteUrl))
-            opn(_hostingInfo.hostingSiteUrl, {wait: false})
+            if(process.env.BROWSER !== 'none'){
+                opn(_hostingInfo.hostingSiteUrl, {wait: false})
+            }
             refreshCloudFront()
         })
     }


### PR DESCRIPTION
#170 

looks at environment variable `BROWSER` if `none` don't open browser after publishing.

similar to how `creact-react-app` supress browesr opening for `start`. https://github.com/facebook/create-react-app/issues/873


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
