### PR TITLE
Added Mobile Hub migrator info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # awsmobile-CLI
 
 > **Important**: The following content applies if you are already using the AWS Mobile CLI to configure your backend. If you are building a new mobile or web app, or you're adding cloud capabilities to your existing app, use the new [AWS Amplify CLI](http://aws-amplify.github.io/) instead. With the new Amplify CLI, you can use all of the features described in [Announcing the AWS Amplify CLI toolchain](http://aws.amazon.com/blogs/mobile/announcing-the-aws-amplify-cli-toolchain/), including AWS CloudFormation functionality that provides additional workflows.
+> **Migrate your Mobile Hub Project to Amplify CLI**: The [Mobile Hub Migrator](https://github.com/awslabs/amplify-mobilehub-migrator) allows you to re-use your existing Mobile Hub resources with the Amplify CLI.
 
 <a href="https://nodei.co/npm/awsmobile-cli/">
   <img src="https://nodei.co/npm/awsmobile-cli.svg?downloads=true&downloadRank=true&stars=true">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # awsmobile-CLI
 
 > **Important**: The following content applies if you are already using the AWS Mobile CLI to configure your backend. If you are building a new mobile or web app, or you're adding cloud capabilities to your existing app, use the new [AWS Amplify CLI](http://aws-amplify.github.io/) instead. With the new Amplify CLI, you can use all of the features described in [Announcing the AWS Amplify CLI toolchain](http://aws.amazon.com/blogs/mobile/announcing-the-aws-amplify-cli-toolchain/), including AWS CloudFormation functionality that provides additional workflows.
+
 > **Migrate your Mobile Hub Project to Amplify CLI**: The [Mobile Hub Migrator](https://github.com/awslabs/amplify-mobilehub-migrator) allows you to re-use your existing Mobile Hub resources with the Amplify CLI.
 
 <a href="https://nodei.co/npm/awsmobile-cli/">


### PR DESCRIPTION
Important: The AWS Mobile CLI is in maintanence mode. If you are building a new mobile or web app, or you're adding cloud capabilities to your existing app, use the new AWS Amplify CLI instead. Use this template to report bugs. For new feature requests refer to the aws-amplify/amplify-cli repository.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
